### PR TITLE
Lrqa 40589

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2054,6 +2054,80 @@ app.server.type=@{app.server.type}]]></echo>
 		<run-empty-temp-dir-test />
 	</target>
 
+	<target name="faces-jdk8">
+  	<property name="liferay.faces.alloy.dir" value="/opt/dev/project/github/liferay-faces-alloy" />
+  	<property name="liferay.faces.bridges.impl.dir" value="/opt/dev/project/github/liferay-faces-bridge-impl" />
+  	<property name="liferay.faces.portal.dir" value="/opt/dev/project/github/liferay-faces-portal" />
+  	<property name="liferay.faces.showcase.dir" value="/opt/dev/project/github/liferay-faces-showcase" />
+
+		<property name="faces.war.files.zip.name" value="all_wars_zipped.zip" />
+		<property name="faces.war.file.url" value="/opt/dev/test_project/${faces.war.files.zip.name}" />
+
+  	<echo>Running with the following repositories:
+* ${project.dir}
+* ${liferay.faces.alloy.dir}
+* ${liferay.faces.bridges.impl.dir}
+* ${liferay.faces.portal.dir}
+* ${liferay.faces.showcase.dir}</echo>
+
+		<antcall target="prepare-portal-ext-properties" />
+
+		<!-- <mirrors-get
+			dest="${liferay.home}/deploy/"
+			src="${faces.war.file.url}"
+		/> -->
+
+		<copy
+			file="${faces.war.file.url}"
+			todir="${liferay.home}/deploy"
+		/>
+
+		<unzip
+			dest="${liferay.home}/deploy/"
+			src="${liferay.home}/deploy/${faces.war.files.zip.name}"
+		/>
+
+		<antcall target="start-app-server" />
+
+    <execute dir="${liferay.faces.showcase.dir}/jsf-showcase-webapp">
+    	mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
+    </execute>
+
+    <execute dir="${liferay.faces.alloy.dir}/demo/alloy-showcase-webapp">
+    	mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
+    </execute>
+
+    <execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
+    	mvn clean install
+    </execute>
+
+    <execute dir="${liferay.faces.portal.dir}/test/integration">
+    	mvn clean install
+    </execute>
+
+		<execute dir="${liferay.faces.bridges.impl.dir}/tck/">
+    	mvn clean install
+    </execute>
+
+    <execute dir="${liferay.faces.bridges.impl.dir}/tck/bridge-tck-main-portlet">
+    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+    </execute>
+
+    <execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
+    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+    </execute>
+
+    <execute dir="${liferay.faces.portal.dir}/test/integration">
+    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+    </execute>
+
+    <execute dir="${liferay.faces.portal.dir}/test/integration">
+    	mvn verify -P selenium-portal-showcase,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+    </execute>
+
+  	<!-- PLACEHOLDER: Need to find all the JUnit Test Results and pass them along to Testray -->
+	</target>
+
 	<target name="functional-bundle-jboss-db2105-jdk8">
 		<run-functional-test
 			app.server.type="jboss"

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -2055,15 +2055,15 @@ app.server.type=@{app.server.type}]]></echo>
 	</target>
 
 	<target name="faces-jdk8">
-  	<property name="liferay.faces.alloy.dir" value="/opt/dev/project/github/liferay-faces-alloy" />
-  	<property name="liferay.faces.bridges.impl.dir" value="/opt/dev/project/github/liferay-faces-bridge-impl" />
-  	<property name="liferay.faces.portal.dir" value="/opt/dev/project/github/liferay-faces-portal" />
-  	<property name="liferay.faces.showcase.dir" value="/opt/dev/project/github/liferay-faces-showcase" />
+		<property name="liferay.faces.alloy.dir" value="/opt/dev/project/github/liferay-faces-alloy" />
+		<property name="liferay.faces.bridges.impl.dir" value="/opt/dev/project/github/liferay-faces-bridge-impl" />
+		<property name="liferay.faces.portal.dir" value="/opt/dev/project/github/liferay-faces-portal" />
+		<property name="liferay.faces.showcase.dir" value="/opt/dev/project/github/liferay-faces-showcase" />
 
 		<property name="faces.war.files.zip.name" value="all_wars_zipped.zip" />
 		<property name="faces.war.file.url" value="/opt/dev/test_project/${faces.war.files.zip.name}" />
 
-  	<echo>Running with the following repositories:
+		<echo>Running with the following repositories:
 * ${project.dir}
 * ${liferay.faces.alloy.dir}
 * ${liferay.faces.bridges.impl.dir}
@@ -2089,43 +2089,42 @@ app.server.type=@{app.server.type}]]></echo>
 
 		<antcall target="start-app-server" />
 
-    <execute dir="${liferay.faces.showcase.dir}/jsf-showcase-webapp">
-    	mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
-    </execute>
+		<execute dir="${liferay.faces.showcase.dir}/jsf-showcase-webapp">
+			mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
+		</execute>
 
-    <execute dir="${liferay.faces.alloy.dir}/demo/alloy-showcase-webapp">
-    	mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
-    </execute>
+		<execute dir="${liferay.faces.alloy.dir}/demo/alloy-showcase-webapp">
+			mvn clean install -P selenium -Dit.test=none -DfailIfNoTests=false
+		</execute>
 
-    <execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
-    	mvn clean install
-    </execute>
+		<execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
+			mvn clean install
+		</execute>
 
-    <execute dir="${liferay.faces.portal.dir}/test/integration">
-    	mvn clean install
-    </execute>
+		<execute dir="${liferay.faces.portal.dir}/test/integration">
+			mvn clean install
+		</execute>
 
 		<execute dir="${liferay.faces.bridges.impl.dir}/tck/">
-    	mvn clean install
-    </execute>
+			mvn clean install
+		</execute>
 
-    <execute dir="${liferay.faces.bridges.impl.dir}/tck/bridge-tck-main-portlet">
-    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
-    </execute>
+		<execute dir="${liferay.faces.bridges.impl.dir}/tck/bridge-tck-main-portlet">
+			mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+		</execute>
 
-    <execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
-    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
-    </execute>
+		<execute dir="${liferay.faces.bridges.impl.dir}/test/integration">
+			mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+		</execute>
 
-    <execute dir="${liferay.faces.portal.dir}/test/integration">
-    	mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
-    </execute>
+		<execute dir="${liferay.faces.portal.dir}/test/integration">
+			mvn verify -P selenium,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+		</execute>
 
-    <execute dir="${liferay.faces.portal.dir}/test/integration">
-    	mvn verify -P selenium-portal-showcase,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
-    </execute>
+		<execute dir="${liferay.faces.portal.dir}/test/integration">
+			mvn verify -P selenium-portal-showcase,firefox -Dwebdriver.firefox.bin=/opt/firefox-46.0/firefox
+		</execute>
 
-  	<!-- PLACEHOLDER: Need to find all the JUnit Test Results and pass them along to Testray -->
 	</target>
 
 	<target name="functional-bundle-jboss-db2105-jdk8">

--- a/build-test.xml
+++ b/build-test.xml
@@ -5688,6 +5688,24 @@ go]]></replacevalue>
 				>
 					<include name="**/TEST-*.xml" />
 				</fileset>
+				<fileset
+					dir="${liferay.faces.bridges.impl.dir}/tck/bridge-tck-main-portlet"
+					erroronmissingdir="false"
+				>
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset
+					dir="${liferay.faces.bridges.impl.dir}/test/integration"
+					erroronmissingdir="false"
+				>
+					<include name="**/TEST-*.xml" />
+				</fileset>
+				<fileset
+					dir="${liferay.faces.portal.dir}/test/integration"
+					erroronmissingdir="false"
+				>
+					<include name="**/TEST-*.xml" />
+				</fileset>
 				<report format="frames" todir="test-results/html" />
 			</junitreport>
 		</parallel>

--- a/build-test.xml
+++ b/build-test.xml
@@ -3993,6 +3993,8 @@ war.path=${app.server.weblogic.portal.dir}/</echo>
 
 					<beanshell>
 						<![CDATA[
+							import java.io.File;
+
 							import org.apache.commons.io.FileUtils;
 
 							import org.apache.tools.ant.DirectoryScanner;
@@ -4002,9 +4004,17 @@ war.path=${app.server.weblogic.portal.dir}/</echo>
 
 								DirectoryScanner directoryScanner = new DirectoryScanner();
 
-								directoryScanner.setIncludes(new String[] {project.getProperty("test.app.server.dir") + "/logs/catalina.*.log"});
+								File logFile = new File(project.getProperty("test.app.server.dir"));
+
+								String canonicalLogFileLocation = logFile.getCanonicalPath();
+
+								System.out.println("canonicalLogFileLocation = " + canonicalLogFileLocation);
+
+								directoryScanner.setIncludes(new String[] {canonicalLogFileLocation + "/logs/catalina.*.log"});
 
 								directoryScanner.scan();
+
+								System.out.println("DIR COUNT: " + directoryScanner.getIncludedFiles().length);
 
 								for (String filePath : directoryScanner.getIncludedFiles()) {
 									String osName = project.getProperty("os.name");


### PR DESCRIPTION
Build-test-batch.xml:
- Replace the commented out mirrors-get and copy with the appropriate method, based on the location of the zipped wars.
- Likely, we'll have to remove the properties being set here and set them as properties in a build.properties file
- This will affect the directories set in build-test.xml, unless the same names are used

Build-test.xml:
- The beanshell changes were mostly for convenience, but I believe that using the canonical path is better than hoping the OS can resolve the relative path
- There's two debug statements in the beanshell that should be removed